### PR TITLE
Avoid sending IPC message every frame while scales are being dragged

### DIFF
--- a/CustomizePlus/Api/CustomizePlusIpc.cs
+++ b/CustomizePlus/Api/CustomizePlusIpc.cs
@@ -150,7 +150,7 @@ namespace CustomizePlus.Api
 
 		}
 
-		public void OnScaleUpdate(string bodyScaleString)
+		public void OnScaleUpdate(string? bodyScaleString)
 		{
 			PluginLog.Debug("Sending c+ ipc scale message.");
 			ProviderOnScaleUpdate?.SendMessage(bodyScaleString);

--- a/CustomizePlus/Api/CustomizePlusIpc.cs
+++ b/CustomizePlus/Api/CustomizePlusIpc.cs
@@ -152,7 +152,7 @@ namespace CustomizePlus.Api
 
 		public void OnScaleUpdate(string? bodyScaleString)
 		{
-			PluginLog.Debug("Sending c+ ipc scale message.");
+			PluginLog.Debug("Sending ipc scale message");
 			ProviderOnScaleUpdate?.SendMessage(bodyScaleString);
 		}
 

--- a/CustomizePlus/Interface/ConfigurationInterface.cs
+++ b/CustomizePlus/Interface/ConfigurationInterface.cs
@@ -56,6 +56,7 @@ namespace CustomizePlus.Interface
 				{
 					config.Save();
 					Plugin.LoadConfig();
+					Plugin.UpdateIpc();
 				}
 			}
 
@@ -192,6 +193,7 @@ namespace CustomizePlus.Interface
 					if (config.AutomaticEditMode)
 					{
 						Plugin.LoadConfig();
+						Plugin.UpdateIpc();
 					}
 				}
 
@@ -236,6 +238,7 @@ namespace CustomizePlus.Interface
 			{
 				config.Save();
 				Plugin.LoadConfig();
+				Plugin.UpdateIpc();
 			}
 
 			ImGui.SameLine();

--- a/CustomizePlus/Interface/EditInterface.cs
+++ b/CustomizePlus/Interface/EditInterface.cs
@@ -106,6 +106,7 @@ namespace CustomizePlus.Interface
 					AddToConfig(this.newScaleName, this.newScaleCharacter);
 					config.Save();
 					Plugin.LoadConfig();
+					Plugin.UpdateIpc();
 				}
 			}
 
@@ -182,6 +183,10 @@ namespace CustomizePlus.Interface
 				{
 					this.UpdateCurrent("Root", new HkVector4(rootScaleLocal.X, rootScaleLocal.Y, rootScaleLocal.Z, rootScaleLocalTemp.W));
 				}
+			}
+			if (ImGui.IsItemDeactivatedAfterEdit() && config.AutomaticEditMode)
+			{
+				Plugin.UpdateIpc();
 			}
 
 			ImGui.Separator();
@@ -343,6 +348,10 @@ namespace CustomizePlus.Interface
 						this.UpdateCurrent(boneNameLocalLegacy, new HkVector4(currentVector4.X, currentVector4.Y, currentVector4.Z, currentVector4.W));
 					}
 				}
+				if (ImGui.IsItemDeactivatedAfterEdit() && config.AutomaticEditMode)
+				{
+					Plugin.UpdateIpc();
+				}
 
 
 				ImGui.PopID();
@@ -361,6 +370,7 @@ namespace CustomizePlus.Interface
 					this.originalScaleName = this.newScaleName;
 				config.Save();
 				Plugin.LoadConfig();
+				Plugin.UpdateIpc();
 			}
 
 			/* TODO feature: undo of some variety. Option below is a revert to what was present when edit was opened, but needs additonal logic
@@ -384,6 +394,7 @@ namespace CustomizePlus.Interface
 			ImGui.SameLine();
 			if (ImGui.Button("Cancel"))
 			{
+				Plugin.UpdateIpc();
 				this.Close();
 			}
 

--- a/CustomizePlus/Interface/InterfaceBase.cs
+++ b/CustomizePlus/Interface/InterfaceBase.cs
@@ -39,6 +39,7 @@ namespace CustomizePlus.Interface
 
 		public virtual void Close()
 		{
+			Plugin.UpdateIpc();
 			this.IsOpen = false;
 		}
 

--- a/CustomizePlus/Plugin.cs
+++ b/CustomizePlus/Plugin.cs
@@ -145,6 +145,7 @@ namespace CustomizePlus
 					{
 						renderManagerHook?.Disable();
 						PluginLog.Debug("Unhooking render function");
+						ipcManager.OnScaleUpdate(null);
 					}
 				}
 				catch (Exception e)


### PR DESCRIPTION
Made a specific method for sending IPC update message and called it from interface items instead of every LoadConfig(). Fixed sending "null" instead of null. Added a check to prevent/lower sending duplicate messages.

I think this is a lot better and fixes some problems with how I was doing it before but it also means I've stuck a bunch of calls in the interface code. If it's true that the interface rework is about to be released then maybe it's not a great idea and I'll have to redo it after that. I don't know. :)